### PR TITLE
Stale data handling

### DIFF
--- a/src/components/shared/Card/Card.js
+++ b/src/components/shared/Card/Card.js
@@ -116,6 +116,7 @@ Card.defaultProps = {
   children: null,
   lastDate: null,
   comparedToDate: null,
+  isTooStale: false,
 };
 
 Card.propTypes = {
@@ -132,6 +133,7 @@ Card.propTypes = {
   children: PropTypes.node,
   lastDate: PropTypes.string,
   comparedToDate: PropTypes.string,
+  isTooStale: PropTypes.bool,
 };
 
 export default Card;

--- a/src/components/shared/Card/Card.js
+++ b/src/components/shared/Card/Card.js
@@ -26,6 +26,7 @@ const Card = ({
   lastDate,
   comparedToDate,
   isNotAvailable,
+  isTooStale,
   isPopulation,
   hint,
   title,
@@ -41,11 +42,12 @@ const Card = ({
     className={cn("Card", className, {
       "Card--population": isPopulation,
       "Card--not-available": isNotAvailable,
+      "Card--too-stale": isTooStale,
     })}
   >
     <div className="Card__header">
       <h3 className="Card__title">{title}</h3>
-      {sourceText && (
+      {!isTooStale && sourceText && (
         <div className="Card__warning-box">
           <button
             type="button"
@@ -64,9 +66,9 @@ const Card = ({
       )}
     </div>
     <div className="Card__body">
-      {isNotAvailable ? (
-        <span className="Card__not-available-text">Not available</span>
-      ) : (
+      {isNotAvailable && <span className="Card__not-available-text">Not available</span>}
+      {isTooStale && <span className="Card__not-available-text">Data is too stale to display</span>}
+      {!isNotAvailable && !isTooStale && (
         <>
           <span className="Card__number">{formatNumber(number)}</span>
           {percentChange === null ? (

--- a/src/components/shared/Card/Card.scss
+++ b/src/components/shared/Card/Card.scss
@@ -41,6 +41,9 @@
     .Card--not-available & {
       color: #808c99;
     }
+    .Card--too-stale & {
+      color: #808c99;
+    }
     .Card--population &:before {
       margin-right: 0.5rem;
       content: "";
@@ -144,6 +147,10 @@
     text-decoration: underline;
   }
 
+  &__last-updated {
+    opacity: 0.5;
+  }
+
   &__body {
     border-top: 1px solid #eeeeee;
     padding: 2rem 1.5rem 2rem;
@@ -194,6 +201,10 @@
   }
 
   &__not-available-text {
+    .Card--too-stale & {
+      font-size: 2rem;
+      white-space: normal;
+    }
     font-size: 2.5rem;
     line-height: 1;
     font-weight: 700;
@@ -202,7 +213,7 @@
     text-transform: capitalize;
     white-space: nowrap;
     @media (max-width: 439px) {
-      font-size: calc(1.5rem + ((100vw - 320px) / 119 * 16));
+      font-size: calc(1.5rem + ((100vw - 320px) / 119 * 16)) !important;
     }
   }
 }

--- a/src/components/shared/Card/__tests__/Card.test.js
+++ b/src/components/shared/Card/__tests__/Card.test.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -49,5 +49,13 @@ describe("Card.js", () => {
     );
 
     expect(container.querySelector(".Card__not-available-text")).toBeInTheDocument();
+  });
+
+  it("should render too stale card if isTooStale flag is set", () => {
+    const { container } = render(
+      <Card title="Some title" number={15} percentChange={-20} isTooStale />
+    );
+
+    expect(container.querySelector(".Card--too-stale")).toBeInTheDocument();
   });
 });

--- a/src/utils/__tests__/metricIsTooStale.test.js
+++ b/src/utils/__tests__/metricIsTooStale.test.js
@@ -1,0 +1,35 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import metricIsTooStale from "../metricIsTooStale";
+
+describe("metricIsTooStale.js", () => {
+  const mockMetric1 = {
+    year: 2019,
+    month: 2,
+  };
+  const mockMetric2 = {
+    year: 2020,
+    month: 2,
+  };
+  const mockMostRecentYear = 2020;
+  const mockMostRecentMonth = 10;
+
+  it("should return true if data is too stale", () => {
+    expect(metricIsTooStale(mockMostRecentYear, mockMostRecentMonth, mockMetric1)).toBe(true);
+    expect(metricIsTooStale(mockMostRecentYear, mockMostRecentMonth, mockMetric2)).toBe(false);
+  });
+});

--- a/src/utils/generateFlowDiagramData.js
+++ b/src/utils/generateFlowDiagramData.js
@@ -82,6 +82,7 @@ const generateFlowDiagramData = (data) => {
             ? `${months[lastItem.comparedToMonth]} ${lastItem.comparedToYear}`
             : null,
           item: lastItem,
+          isTooStale: false,
         };
 
         if (acc.mostRecentYear < lastItem.year) {
@@ -97,14 +98,25 @@ const generateFlowDiagramData = (data) => {
     { flowData: {}, mostRecentYear: -Infinity, mostRecentMonth: -Infinity }
   );
 
-  Object.values(flowData).forEach((item) => {
-    const hint = item.isNotAvailable
+  Object.values(flowData).forEach((metric) => {
+    const hint = metric.isNotAvailable
       ? null
-      : generateHint(mostRecentYear, mostRecentMonth, item.item);
+      : generateHint(mostRecentYear, mostRecentMonth, metric.item);
 
     if (hint) {
       // eslint-disable-next-line no-param-reassign
-      item.hint = hint;
+      metric.hint = hint;
+    }
+
+    const { item } = metric;
+
+    const isTooStale = metric.isNotAvailable
+      ? null
+      : item.month < mostRecentMonth && item.year <= mostRecentYear - 1;
+
+    if (isTooStale) {
+      // eslint-disable-next-line no-param-reassign
+      metric.isTooStale = isTooStale;
     }
   });
 

--- a/src/utils/generateFlowDiagramData.js
+++ b/src/utils/generateFlowDiagramData.js
@@ -30,6 +30,7 @@ import {
 import generateHint from "./generateHint";
 import months from "../constants/months";
 import generateSourceText from "./generateSourceText";
+import metricIsTooStale from "./metricIsTooStale";
 
 /**
  * Prepares data for flow Diagram
@@ -98,25 +99,10 @@ const generateFlowDiagramData = (data) => {
     { flowData: {}, mostRecentYear: -Infinity, mostRecentMonth: -Infinity }
   );
 
-  Object.values(flowData).forEach((metric) => {
-    const hint = metric.isNotAvailable
-      ? null
-      : generateHint(mostRecentYear, mostRecentMonth, metric.item);
-
-    if (hint) {
-      // eslint-disable-next-line no-param-reassign
-      metric.hint = hint;
-    }
-
-    const { item } = metric;
-
-    const isTooStale = metric.isNotAvailable
-      ? null
-      : item.month < mostRecentMonth && item.year <= mostRecentYear - 1;
-
-    if (isTooStale) {
-      // eslint-disable-next-line no-param-reassign
-      metric.isTooStale = isTooStale;
+  Object.values(flowData).forEach((item) => {
+    if (!item.isNotAvailable) {
+      item.isTooStale = metricIsTooStale(mostRecentYear, mostRecentMonth, item.item); // eslint-disable-line no-param-reassign
+      item.hint = generateHint(mostRecentYear, mostRecentMonth, item.item); // eslint-disable-line no-param-reassign
     }
   });
 

--- a/src/utils/metricIsTooStale.js
+++ b/src/utils/metricIsTooStale.js
@@ -1,0 +1,22 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+const metricIsTooStale = (mostRecentYear, mostRecentMonth, item) => {
+  // A metric is too stale if its month and year are earlier than the month and year we are comparing metrics against
+  return item.month < mostRecentMonth && item.year <= mostRecentYear - 1;
+};
+
+export default metricIsTooStale;


### PR DESCRIPTION
## Description of the change

Added logic to handle stale data displaying.
If data for given metric do not overlap primary range the metric doesn't displaying.
Example: 
![screencapture-localhost-3000-2021-03-22-19_00_27](https://user-images.githubusercontent.com/20225344/112021036-ecfbeb80-8b41-11eb-98b6-a59471722478.png)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #56 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
