### PR TITLE
Add validation/constraint for statewide incarceration rate calculation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,7 +107,7 @@ const App = ({ stateCode, correctionsData, jailsData, countiesData }) => {
     releasesChartData.sourceData,
   ]);
 
-  const { jailsKeyInsightsData, countyCoverage } = generateJailsKeyInsightsData(
+  const jailsKeyInsightsData = generateJailsKeyInsightsData(
     jailsMetricData,
     <ReportingCounties stateName={stateName} counties={normalizedCountyData} />
   );
@@ -122,8 +122,7 @@ const App = ({ stateCode, correctionsData, jailsData, countiesData }) => {
     jailsMetricData,
     INCARCERATION_RATE_JAIL,
     ["Statewide", selectorCountyCode],
-    ["Statewide", selectorCountyName],
-    countyCoverage
+    ["Statewide", selectorCountyName]
   );
 
   const incarcerationRateTopCountiesChartData = generateJailsChartData(

--- a/src/components/shared/Chart/Chart.js
+++ b/src/components/shared/Chart/Chart.js
@@ -58,6 +58,7 @@ const Chart = ({ title, hint, chartData, countySelector }) => {
   const styledDatasets = datasets.map((dataset, i) => ({
     ...dataset,
     data: dataset.data,
+    countyCoverageData: dataset.countyCoverageData,
     borderColor: chartColors[i],
     isNotAvailable: dataset.isNotAvailable || dataset.data.every((dataPoint) => dataPoint === null),
     backgroundColor: "transparent",
@@ -154,12 +155,14 @@ const Chart = ({ title, hint, chartData, countySelector }) => {
                   label: (tooltipItem, data) =>
                     `${
                       data.datasets[tooltipItem.datasetIndex].isStatewide
-                        ? `${data.datasets[tooltipItem.datasetIndex].label} ${
-                            data.datasets[tooltipItem.datasetIndex].countyCoverage
-                          }`
+                        ? `${data.datasets[tooltipItem.datasetIndex].label} (${formatNumber(
+                            data.datasets[tooltipItem.datasetIndex].countyCoverageData[
+                              tooltipItem.index
+                            ]
+                          )}% counties reporting)`
                         : data.datasets[tooltipItem.datasetIndex].label
                     }: ${formatNumber(tooltipItem.value)} ${
-                      styledDatasets.some((dataset) => dataset.county) ? "per 100,000" : ""
+                      data.datasets.some((dataset) => dataset.county) ? "per 100,000" : ""
                     }`,
                 },
                 backgroundColor: CONNECTING_LINE_COLOR,
@@ -186,7 +189,7 @@ const Chart = ({ title, hint, chartData, countySelector }) => {
               />
               <span className="Chart__legend-label">
                 {dataset.label}&nbsp;
-                {dataset.isStatewide ? dataset.countyCoverage : countySelector}
+                {!dataset.isStatewide ? countySelector : null}
               </span>
               <span className="Chart__legend-percent">
                 {dataset.isNotAvailable ? "N/A" : calcMetricPercentage(dataset.data)}

--- a/src/components/shared/Chart/utils/__tests__/adjustChartDataLength.test.js
+++ b/src/components/shared/Chart/utils/__tests__/adjustChartDataLength.test.js
@@ -45,8 +45,8 @@ describe("processToLength.js", () => {
 
     it("should fill datasets with nulls", () => {
       expect(datasets).toStrictEqual([
-        { label: "One", data: [null, null, null, null, 300] },
-        { label: "Two", data: [null, null, 100, 201, 304] },
+        { label: "One", data: [null, null, null, null, 300], countyCoverageData: [] },
+        { label: "Two", data: [null, null, 100, 201, 304], countyCoverageData: [] },
       ]);
     });
   });
@@ -77,8 +77,8 @@ describe("processToLength.js", () => {
 
     it("should cut datasets", () => {
       expect(datasets).toStrictEqual([
-        { label: "One", data: [null, 300] },
-        { label: "Two", data: [201, 304] },
+        { label: "One", data: [null, 300], countyCoverageData: [] },
+        { label: "Two", data: [201, 304], countyCoverageData: [] },
       ]);
     });
   });

--- a/src/components/shared/Chart/utils/adjustChartDataLength.js
+++ b/src/components/shared/Chart/utils/adjustChartDataLength.js
@@ -31,6 +31,11 @@ const adjustChartDataLength = (data, targetLength) => {
     datasets: data.datasets.map((dataset) => ({
       ...dataset,
       data: Array.from({ length: lengthDiff }).fill(null).concat(dataset.data.slice(-targetLength)),
+      countyCoverageData: dataset.countyCoverageData
+        ? Array.from({ length: lengthDiff })
+            .fill(null)
+            .concat(dataset.countyCoverageData.slice(-targetLength))
+        : [],
     })),
     labels: Array.from({ length: lengthDiff })
       .map((_, i) => ({

--- a/src/components/shared/KeyInsights/propTypes.js
+++ b/src/components/shared/KeyInsights/propTypes.js
@@ -4,7 +4,7 @@ export const keyInsightsPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
     title: PropTypes.string.isRequired,
     number: PropTypes.number.isRequired,
-    percentChange: PropTypes.number.isRequired,
+    percentChange: PropTypes.number,
     caption: PropTypes.string.isRequired,
   })
 );

--- a/src/constants/constraints.js
+++ b/src/constants/constraints.js
@@ -1,0 +1,17 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+export const MIN_COVERED_POPULATION = 0.1;

--- a/src/utils/__tests__/generateJailsChartData.test.js
+++ b/src/utils/__tests__/generateJailsChartData.test.js
@@ -155,13 +155,12 @@ describe("generateJailsChartData.js", () => {
   describe("should work with additional data", () => {
     const mockJailsData = {
       [INCARCERATION_RATE_JAIL]: [
-        { year: 2020, month: 8, value: 102 },
-        { year: 2020, month: 9, value: 103 },
-        { year: 2020, month: 10, value: 104 },
+        { year: 2020, month: 8, value: 102, countyCoverage: 0.123 },
+        { year: 2020, month: 9, value: 103, countyCoverage: 0.124 },
+        { year: 2020, month: 10, value: 104, countyCoverage: 0.125 },
       ],
     };
     const mockStatewide = "Statewide";
-    const mockCountyCoverage = 10;
 
     it("should put isStatewide flag if county set as Statewide", () => {
       expect(
@@ -190,14 +189,13 @@ describe("generateJailsChartData.js", () => {
       });
     });
 
-    it("should put countyCoverage caption if countyCoverage value is provided", () => {
+    it("should put fill countyCoverageData array if countyCoverage values are provided", () => {
       expect(
         generateJailsChartData(
           mockJailsData,
           INCARCERATION_RATE_JAIL,
           [mockStatewide],
-          [mockStatewide],
-          mockCountyCoverage
+          [mockStatewide]
         )
       ).toMatchObject({
         datasets: [
@@ -206,9 +204,9 @@ describe("generateJailsChartData.js", () => {
             county: mockStatewide,
             label: mockStatewide,
             data: [102, 103, 104],
+            countyCoverageData: [12.3, 12.4, 12.5],
             isNotAvailable: false,
             isStatewide: true,
-            countyCoverage: `(${mockCountyCoverage}% counties reporting)`,
           },
         ],
         labels: [

--- a/src/utils/__tests__/generateJailsKeyInsightsData.test.js
+++ b/src/utils/__tests__/generateJailsKeyInsightsData.test.js
@@ -55,7 +55,7 @@ describe("generateJailsKeyInsightsData.js", () => {
     ],
   };
 
-  const { jailsKeyInsightsData } = generateJailsKeyInsightsData(mockData);
+  const jailsKeyInsightsData = generateJailsKeyInsightsData(mockData);
 
   it("should put isNumberPercent flag if metric value less than 1", () => {
     expect(jailsKeyInsightsData[1].isNumberPercent).toBe(true);

--- a/src/utils/generateJailsChartData.js
+++ b/src/utils/generateJailsChartData.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import { METRICS_NOT_PROVIDED } from "../constants/errors";
-import formatNumber from "./formatNumber";
 import logger from "./logger";
 import chartPeriods from "./chartPeriods";
 
@@ -43,7 +42,7 @@ export const noMetricData = (metric) =>
  * }}
  */
 
-const generateJailsChartData = (data, metric, counties, countyLabels = [], countyCoverage) => {
+const generateJailsChartData = (data, metric, counties, countyLabels = []) => {
   if (!metric.length) {
     throw new Error(METRICS_NOT_PROVIDED);
   }
@@ -56,13 +55,11 @@ const generateJailsChartData = (data, metric, counties, countyLabels = [], count
     acc.push({
       metric,
       county,
-      countyCoverage: countyCoverage
-        ? `(${formatNumber(countyCoverage)}% counties reporting)`
-        : null,
       label: countyLabels[index],
       isNotAvailable: !data[metric],
       isStatewide: county === "Statewide",
       data: [],
+      countyCoverageData: [],
     });
 
     return acc;
@@ -87,6 +84,9 @@ const generateJailsChartData = (data, metric, counties, countyLabels = [], count
         );
         if (dataPoint) {
           dataset.data.push(dataPoint.value);
+          if (dataset.isStatewide) {
+            dataset.countyCoverageData.push(dataPoint.countyCoverage * 100);
+          }
         } else {
           dataset.data.push(null);
         }

--- a/src/utils/generateJailsChartData.js
+++ b/src/utils/generateJailsChartData.js
@@ -86,6 +86,7 @@ const generateJailsChartData = (data, metric, counties, countyLabels = []) => {
           dataset.data.push(dataPoint.value);
           if (dataset.isStatewide) {
             dataset.countyCoverageData.push(dataPoint.countyCoverage * 100);
+            if (dataPoint.populationCoverage < 0.1) dataset.data.push(null);
           }
         } else {
           dataset.data.push(null);

--- a/src/utils/generateJailsChartData.js
+++ b/src/utils/generateJailsChartData.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+import { MIN_COVERED_POPULATION } from "../constants/constraints";
 import { METRICS_NOT_PROVIDED } from "../constants/errors";
 import logger from "./logger";
 import chartPeriods from "./chartPeriods";
@@ -86,7 +87,7 @@ const generateJailsChartData = (data, metric, counties, countyLabels = []) => {
           dataset.data.push(dataPoint.value);
           if (dataset.isStatewide) {
             dataset.countyCoverageData.push(dataPoint.countyCoverage * 100);
-            if (dataPoint.populationCoverage < 0.1) {
+            if (dataPoint.populationCoverage < MIN_COVERED_POPULATION) {
               dataset.data.pop();
               dataset.data.push(null);
             }

--- a/src/utils/generateJailsChartData.js
+++ b/src/utils/generateJailsChartData.js
@@ -96,7 +96,6 @@ const generateJailsChartData = (data, metric, counties, countyLabels = []) => {
         }
       }
     });
-    console.log(datasets);
 
     i += 1;
   }

--- a/src/utils/generateJailsChartData.js
+++ b/src/utils/generateJailsChartData.js
@@ -86,13 +86,17 @@ const generateJailsChartData = (data, metric, counties, countyLabels = []) => {
           dataset.data.push(dataPoint.value);
           if (dataset.isStatewide) {
             dataset.countyCoverageData.push(dataPoint.countyCoverage * 100);
-            if (dataPoint.populationCoverage < 0.1) dataset.data.push(null);
+            if (dataPoint.populationCoverage < 0.1) {
+              dataset.data.pop();
+              dataset.data.push(null);
+            }
           }
         } else {
           dataset.data.push(null);
         }
       }
     });
+    console.log(datasets);
 
     i += 1;
   }

--- a/src/utils/generateJailsKeyInsightsData.js
+++ b/src/utils/generateJailsKeyInsightsData.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+import { MIN_COVERED_POPULATION } from "../constants/constraints";
 import {
   POPULATION_JAIL,
   PERCENTAGE_COVERED_COUNTY,
@@ -36,6 +37,10 @@ const generatePopulationCaption = (percentChange, numberChange) => {
     return `There was no net change in jail population during this time period.`;
   }
 
+  if (numberChange === null) {
+    return `There is no available net change in jail population during this time period.`;
+  }
+
   return `The jail population ${numberChange > 0 ? "rose" : "fell"} by ${Math.abs(
     Math.round(percentChange)
   )} percent in the past year, a ${numberChange > 0 ? "increase" : "decline"} of ${Math.abs(
@@ -46,6 +51,10 @@ const generatePopulationCaption = (percentChange, numberChange) => {
 const generateIncarcerationCaption = (percentChange, numberChange) => {
   if (numberChange === 0) {
     return `There was no net change in incarceration rate during this time period.`;
+  }
+
+  if (numberChange === null) {
+    return `There is no available net change in incarceration rate during this time period.`;
   }
 
   return `The incarceration rate for those in jail ${
@@ -85,7 +94,14 @@ const generateJailsKeyInsightsData = (data, reportingCountiesModal) => {
           isNotAvailable: true,
         };
       } else {
-        const generalData = data[metric].filter((item) => item.countyCode === undefined);
+        const constraintMonths = data[INCARCERATION_RATE_JAIL].filter(
+          (item) => item.populationCoverage < MIN_COVERED_POPULATION
+        ).map((item) => item.month);
+
+        const generalData = data[metric].filter(
+          (item) => item.countyCode === undefined && !constraintMonths.includes(item.month)
+        );
+
         if (!generalData.length) {
           acc.flowData[metric] = {
             title: metricToCardName[metric],
@@ -98,7 +114,7 @@ const generateJailsKeyInsightsData = (data, reportingCountiesModal) => {
           acc.flowData[metric] = {
             title: metricToCardName[metric],
             number: lastItem.value < 1 ? lastItem.value * 100 : lastItem.value,
-            percentChange: lastItem.percentChange * 100,
+            percentChange: lastItem.percentChange ? lastItem.percentChange * 100 : null,
             numberChange: lastItem.valueChange,
             populationCoverage: lastItem.populationCoverage * 100,
             countyCoverage: lastItem.countyCoverage * 100,

--- a/src/utils/generateJailsKeyInsightsData.js
+++ b/src/utils/generateJailsKeyInsightsData.js
@@ -147,10 +147,7 @@ const generateJailsKeyInsightsData = (data, reportingCountiesModal) => {
     return keyInsights;
   }, []);
 
-  return {
-    jailsKeyInsightsData,
-    countyCoverage: flowData[PERCENTAGE_COVERED_COUNTY].number,
-  };
+  return jailsKeyInsightsData;
 };
 
 export default generateJailsKeyInsightsData;


### PR DESCRIPTION
## Description of the change

1. Fixed counties reporting caption in graph tooltip to match #99 requirements.
2. Added arbitrary floor (10% population covered) as validation to statewide graph 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #100 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
