### PR TITLE
Slight tweaks to fix constraint logic

### DIFF
--- a/src/utils/generateJailsKeyInsightsData.js
+++ b/src/utils/generateJailsKeyInsightsData.js
@@ -95,12 +95,18 @@ const generateJailsKeyInsightsData = (data, reportingCountiesModal) => {
           isNotAvailable: true,
         };
       } else {
-        const constraintMonths = data[INCARCERATION_RATE_JAIL].filter(
-          (item) => item.populationCoverage < MIN_COVERED_POPULATION
-        ).map((item) => item.month);
+        console.log(data[INCARCERATION_RATE_JAIL]);
+        const constraintMonths = new Set(
+          data[INCARCERATION_RATE_JAIL].filter(
+            (item) =>
+              item.countyCode === undefined && item.populationCoverage < MIN_COVERED_POPULATION
+          ).map((item) => `${item.year}-${item.month}`)
+        );
+        console.log(constraintMonths);
 
         const generalData = data[metric].filter(
-          (item) => item.countyCode === undefined && !constraintMonths.includes(item.month)
+          (item) =>
+            item.countyCode === undefined && !constraintMonths.has(`${item.year}-${item.month}`)
         );
 
         if (!generalData.length) {

--- a/src/utils/generateJailsKeyInsightsData.js
+++ b/src/utils/generateJailsKeyInsightsData.js
@@ -95,14 +95,12 @@ const generateJailsKeyInsightsData = (data, reportingCountiesModal) => {
           isNotAvailable: true,
         };
       } else {
-        console.log(data[INCARCERATION_RATE_JAIL]);
         const constraintMonths = new Set(
           data[INCARCERATION_RATE_JAIL].filter(
             (item) =>
               item.countyCode === undefined && item.populationCoverage < MIN_COVERED_POPULATION
           ).map((item) => `${item.year}-${item.month}`)
         );
-        console.log(constraintMonths);
 
         const generalData = data[metric].filter(
           (item) =>


### PR DESCRIPTION
## Description of the change

Please pardon my terrible javascript 😁  noticed a couple issues while prepping for a demo this morning, two small changes plus accompanying tests:

* includes year in constraint months, so that low coverage for a month doesn't remove that month in every year
* only check statewide incarceration rate when determining constraint months
  * our production data currently produces coverage info for county level data also, which isn't very useful so I may remove it but figured we should protect against this in the frontend anyway

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

follow up to #100 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
