### PR TITLE
Rename PROBATION_SENTENCES to SUPERVISION_STARTS_PROBATION

### DIFF
--- a/src/components/Corrections/FlowDiagram/FlowDiagram.js
+++ b/src/components/Corrections/FlowDiagram/FlowDiagram.js
@@ -23,7 +23,7 @@ import Arrow from "./Arrow";
 
 import {
   ADMISSIONS_NEW_COMMITMENTS,
-  PROBATION_SENTENCES,
+  SUPERVISION_STARTS_PROBATION,
   ADMISSIONS_FROM_PAROLE,
   ADMISSIONS_FROM_PROBATION,
   POPULATION_PAROLE,
@@ -61,10 +61,10 @@ const FlowDiagram = ({ data, lastDate, prevDate }) => {
               mobilePlacement="left"
             />
           </Card>
-          <Card className="FlowDiagram__card" {...data[PROBATION_SENTENCES]}>
+          <Card className="FlowDiagram__card" {...data[SUPERVISION_STARTS_PROBATION]}>
             <Arrow
               isDisabled={
-                data[PROBATION_SENTENCES].isNotAvailable ||
+                data[SUPERVISION_STARTS_PROBATION].isNotAvailable ||
                 data[POPULATION_PROBATION].isNotAvailable
               }
               height={4.25}

--- a/src/components/Corrections/FlowDiagram/__tests__/FlowDiagram.test.js
+++ b/src/components/Corrections/FlowDiagram/__tests__/FlowDiagram.test.js
@@ -19,7 +19,7 @@ import { render } from "@testing-library/react";
 import FlowDiagram from "../FlowDiagram";
 import {
   ADMISSIONS_NEW_COMMITMENTS,
-  PROBATION_SENTENCES,
+  SUPERVISION_STARTS_PROBATION,
   ADMISSIONS_FROM_PAROLE,
   ADMISSIONS_FROM_PROBATION,
   POPULATION_PAROLE,
@@ -33,7 +33,7 @@ describe("FlowDiagram.js", () => {
   const mockPrevDate = "October 2019";
   const mockData = {
     [ADMISSIONS_NEW_COMMITMENTS]: { title: "ADMISSIONS", isNotAvailable: false },
-    [PROBATION_SENTENCES]: { title: "ADMISSIONS_NEW_COURT", isNotAvailable: false },
+    [SUPERVISION_STARTS_PROBATION]: { title: "ADMISSIONS_NEW_COURT", isNotAvailable: false },
     [POPULATION_PRISON]: { title: "POPULATION_PRISON", isNotAvailable: false },
     [POPULATION_PROBATION]: { title: "POPULATION_PROBATION", isNotAvailable: false },
     [ADMISSIONS_FROM_PROBATION]: {

--- a/src/constants/metrics.js
+++ b/src/constants/metrics.js
@@ -16,7 +16,7 @@
 // =============================================================================
 export const ADMISSIONS = "ADMISSIONS";
 export const ADMISSIONS_NEW_COMMITMENTS = "ADMISSIONS_NEW_COMMITMENTS";
-export const PROBATION_SENTENCES = "PROBATION_SENTENCES";
+export const SUPERVISION_STARTS_PROBATION = "SUPERVISION_STARTS_PROBATION";
 export const ADMISSIONS_FROM_PAROLE = "ADMISSIONS_FROM_PAROLE";
 export const ADMISSIONS_FROM_PAROLE_NEW_CRIME = "ADMISSIONS_FROM_PAROLE_NEW_CRIME";
 export const ADMISSIONS_FROM_PROBATION = "ADMISSIONS_FROM_PROBATION";
@@ -31,7 +31,7 @@ export const ADMISSIONS_FROM_PROBATION_TECHNICAL = "ADMISSIONS_FROM_PROBATION_TE
 
 export const metricToCardName = {
   [ADMISSIONS_NEW_COMMITMENTS]: "New Prison Commitments",
-  [PROBATION_SENTENCES]: "New Probation Commitments",
+  [SUPERVISION_STARTS_PROBATION]: "New Probation Commitments",
   [POPULATION_PROBATION]: "Probation Population",
   [ADMISSIONS_FROM_PROBATION]: "Probation Revocations",
   [POPULATION_PRISON]: "Prison Population",

--- a/src/utils/__tests__/generateFlowDiagramData.test.js
+++ b/src/utils/__tests__/generateFlowDiagramData.test.js
@@ -19,7 +19,7 @@ import generateHint from "../generateHint";
 import generateSourceText from "../generateSourceText";
 import {
   ADMISSIONS_NEW_COMMITMENTS,
-  PROBATION_SENTENCES,
+  SUPERVISION_STARTS_PROBATION,
   ADMISSIONS_FROM_PAROLE,
   ADMISSIONS_FROM_PROBATION,
   POPULATION_PAROLE,
@@ -88,7 +88,7 @@ describe("generateFlowDiagramData.js", () => {
   });
 
   it("should put isNotAvailable flag is no metric data provided", () => {
-    expect(flowDiagramData.flowData[PROBATION_SENTENCES].isNotAvailable).toBe(true);
+    expect(flowDiagramData.flowData[SUPERVISION_STARTS_PROBATION].isNotAvailable).toBe(true);
     expect(flowDiagramData.flowData[ADMISSIONS_FROM_PROBATION].isNotAvailable).toBe(true);
     expect(flowDiagramData.flowData[POPULATION_PRISON].isNotAvailable).toBe(true);
     expect(flowDiagramData.flowData[POPULATION_PAROLE].isNotAvailable).toBe(true);

--- a/src/utils/generateFlowDiagramData.js
+++ b/src/utils/generateFlowDiagramData.js
@@ -18,7 +18,7 @@ import {
   ADMISSIONS_NEW_COMMITMENTS,
   ADMISSIONS_FROM_PAROLE_TECHNICAL,
   ADMISSIONS_FROM_PROBATION_TECHNICAL,
-  PROBATION_SENTENCES,
+  SUPERVISION_STARTS_PROBATION,
   ADMISSIONS_FROM_PAROLE,
   ADMISSIONS_FROM_PROBATION,
   metricToCardName,
@@ -58,7 +58,7 @@ import metricIsPartiallyAvailable from "./metricIsPartiallyAvailable";
 const generateFlowDiagramData = (data, compareData, stateName, isAnnual) => {
   const { flowData, mostRecentYear, mostRecentMonth } = [
     ADMISSIONS_NEW_COMMITMENTS,
-    PROBATION_SENTENCES,
+    SUPERVISION_STARTS_PROBATION,
     POPULATION_PROBATION,
     ADMISSIONS_FROM_PROBATION,
     POPULATION_PRISON,


### PR DESCRIPTION
## Description of the change

These really reflect new starts to probation, not sentences, so this renames the metric to match what we have implemented on the backend.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Recidiviz/recidiviz-data#7583

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
