### PR TITLE
Disable jails tab for unified states

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,6 +47,8 @@ import {
   ADMISSIONS_FROM_PROBATION_NEW_CRIME,
   INCARCERATION_RATE_JAIL,
 } from "./constants/metrics";
+import getIsUnified from "./utils/getIsUnified";
+import getAdditionalDescription from "./utils/getAdditionalDescription";
 
 const App = ({
   stateCode,
@@ -257,6 +259,9 @@ const App = ({
     },
   ];
 
+  const isUnified = getIsUnified(stateCode);
+  const additionalDescription = getAdditionalDescription(stateCode);
+
   return (
     <MainPage
       stateName={stateName}
@@ -270,6 +275,8 @@ const App = ({
       correctionsLastUpdatedDate={monthlyFlowData.correctionsLastUpdatedDate}
       jailsSourceData={jailsSourceData}
       isNoData={isNoData}
+      isUnified={isUnified}
+      additionalDescription={additionalDescription}
     />
   );
 };

--- a/src/components/MainPage/MainPage.js
+++ b/src/components/MainPage/MainPage.js
@@ -43,8 +43,13 @@ const MainPage = ({
   countySelector,
   jailsSourceData,
   isNoData,
+  isUnified,
+  additionalDescription,
 }) => {
-  const [activeTab, setActiveTab] = useState(localStorage.getItem(LS_TAB_KEY) || CORRECTIONS);
+  const [storedActiveTab, setActiveTab] = useState(localStorage.getItem(LS_TAB_KEY) || CORRECTIONS);
+
+  // Force the active tab to 'CORRECTIONS' in a unified state.
+  const activeTab = isUnified ? CORRECTIONS : storedActiveTab;
 
   const onActiveTabChange = (newTab) => {
     setActiveTab(newTab);
@@ -81,7 +86,7 @@ const MainPage = ({
             <p className="MainPage__description">
               The following is a broad overview of the corrections system in {stateName},
               representing up-to-date data and changes compared to last year. An additional section
-              on crime indicators will be added at a later date.
+              on crime indicators will be added at a later date. {additionalDescription}
               <br />
               <i>
                 Last updated:{" "}
@@ -93,7 +98,7 @@ const MainPage = ({
       </header>
       {!isNoData && (
         <>
-          <Tabs activeTab={activeTab} onTabChange={onActiveTabChange} />
+          <Tabs activeTab={activeTab} onTabChange={onActiveTabChange} isUnified={isUnified} />
           {activeTab === CORRECTIONS && (
             <div className="MainPage__range">
               <h3 className="MainPage__range-title">Data Aggregation Range</h3>
@@ -138,6 +143,7 @@ const MainPage = ({
 
 MainPage.defaultProps = {
   countySelector: null,
+  additionalDescription: null,
 };
 
 MainPage.propTypes = {
@@ -152,6 +158,8 @@ MainPage.propTypes = {
   countySelector: PropTypes.node,
   jailsSourceData: PropTypes.arrayOf(PropTypes.shape(sourcePropTypes)).isRequired,
   isNoData: PropTypes.bool.isRequired,
+  isUnified: PropTypes.bool.isRequired,
+  additionalDescription: PropTypes.string,
 };
 
 export default MainPage;

--- a/src/components/MainPage/MainPage.scss
+++ b/src/components/MainPage/MainPage.scss
@@ -102,9 +102,16 @@
 
     &_active,
     &:hover {
-      background: #06aeee;
-      color: #fff;
+      &:not(.MainPage__tab--disabled) {
+        background: #06aeee;
+        color: #fff;
+      }
     }
+
+    // .MainPage__tab--disabled &:hover {
+    //   background: none;
+    //   color: none;
+    // }
   }
 
   &__range {

--- a/src/components/MainPage/MainPage.scss
+++ b/src/components/MainPage/MainPage.scss
@@ -107,11 +107,6 @@
         color: #fff;
       }
     }
-
-    // .MainPage__tab--disabled &:hover {
-    //   background: none;
-    //   color: none;
-    // }
   }
 
   &__range {

--- a/src/components/MainPage/Tabs.js
+++ b/src/components/MainPage/Tabs.js
@@ -47,7 +47,6 @@ const Tabs = ({ activeTab, onTabChange, isUnified }) => {
     </div>
   );
 };
-// This state operates a "unified corrections system," which combines the jail and prison systems. As such, some of the numbers below may include pre-trial populations.
 
 Tabs.propTypes = {
   activeTab: PropTypes.oneOf([CORRECTIONS, JAILS]).isRequired,

--- a/src/components/MainPage/Tabs.js
+++ b/src/components/MainPage/Tabs.js
@@ -20,7 +20,7 @@ import cn from "classnames";
 
 import { CORRECTIONS, JAILS } from "./constants";
 
-const Tabs = ({ activeTab, onTabChange }) => {
+const Tabs = ({ activeTab, onTabChange, isUnified }) => {
   const createOnTabChange = (tab) => () => {
     onTabChange(tab);
   };
@@ -36,18 +36,23 @@ const Tabs = ({ activeTab, onTabChange }) => {
       </button>
       <button
         type="button"
-        className={cn("MainPage__tab", { MainPage__tab_active: activeTab === JAILS })}
-        onClick={createOnTabChange(JAILS)}
+        className={cn("MainPage__tab", {
+          MainPage__tab_active: activeTab === JAILS,
+          "MainPage__tab--disabled": isUnified,
+        })}
+        onClick={isUnified ? null : createOnTabChange(JAILS)}
       >
-        Jails
+        Jails{isUnified && " (Not Applicable)"}
       </button>
     </div>
   );
 };
+// This state operates a "unified corrections system," which combines the jail and prison systems. As such, some of the numbers below may include pre-trial populations.
 
 Tabs.propTypes = {
   activeTab: PropTypes.oneOf([CORRECTIONS, JAILS]).isRequired,
   onTabChange: PropTypes.func.isRequired,
+  isUnified: PropTypes.bool.isRequired,
 };
 
 export default Tabs;

--- a/src/components/MainPage/__tests__/MainPage.test.js
+++ b/src/components/MainPage/__tests__/MainPage.test.js
@@ -19,6 +19,7 @@ import { render } from "@testing-library/react";
 
 import MainPage from "../MainPage";
 import Corrections from "../../Corrections";
+import { JAILS, LS_TAB_KEY } from "../constants";
 
 jest.mock("../../Corrections");
 describe("MainPage.js", () => {
@@ -50,9 +51,51 @@ describe("MainPage.js", () => {
         incarcerationRateChartData={{}}
         incarcerationRateTopCountiesChartData={{}}
         jailsSourceData={[]}
+        isUnified={false}
       />
     );
 
     expect(container.querySelector(".MainPage__title").innerHTML).toBe("Alabama data dashboard");
+  });
+
+  it("should always render corrections if unified", () => {
+    localStorage.setItem(LS_TAB_KEY, JAILS);
+    const { container } = render(
+      <MainPage
+        stateName={mockStateName}
+        monthlyCorrectionsData={mockCorrectionsData}
+        annualCorrectionsData={mockCorrectionsData}
+        jailsKeyInsightsData={[]}
+        incarcerationRateChartData={{}}
+        incarcerationRateTopCountiesChartData={{}}
+        jailsSourceData={[]}
+        isUnified
+      />
+    );
+
+    expect(container.querySelector(".MainPage__tab_active").innerHTML).toBe("Corrections");
+  });
+
+  const mockJailChartData = {
+    datasets: [],
+    labels: [],
+  };
+
+  it("should always render jails if not unified", () => {
+    localStorage.setItem(LS_TAB_KEY, JAILS);
+    const { container } = render(
+      <MainPage
+        stateName={mockStateName}
+        monthlyCorrectionsData={mockCorrectionsData}
+        annualCorrectionsData={mockCorrectionsData}
+        jailsKeyInsightsData={[]}
+        incarcerationRateChartData={mockJailChartData}
+        incarcerationRateTopCountiesChartData={mockJailChartData}
+        jailsSourceData={[]}
+        isUnified={false}
+      />
+    );
+
+    expect(container.querySelector(".MainPage__tab_active").innerHTML).toBe("Jails");
   });
 });

--- a/src/utils/getAdditionalDescription.js
+++ b/src/utils/getAdditionalDescription.js
@@ -1,0 +1,27 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import getIsUnified from "./getIsUnified";
+
+// =============================================================================
+const getAdditionalDescription = (stateCode) => {
+  if (getIsUnified(stateCode)) {
+    return `This state operates a "unified corrections system," which combines the jail and prison systems. As such, some of the numbers below may include pre-trial populations.`;
+  }
+  return null;
+};
+
+export default getAdditionalDescription;

--- a/src/utils/getIsUnified.js
+++ b/src/utils/getIsUnified.js
@@ -17,15 +17,10 @@
 const getIsUnified = (stateCode) => {
   switch (stateCode) {
     case "US_AK":
-      return true;
     case "US_CT":
-      return true;
     case "US_DE":
-      return true;
     case "US_HI":
-      return true;
     case "US_RI":
-      return true;
     case "US_VT":
       return true;
     default:

--- a/src/utils/getIsUnified.js
+++ b/src/utils/getIsUnified.js
@@ -1,0 +1,36 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+const getIsUnified = (stateCode) => {
+  switch (stateCode) {
+    case "US_AK":
+      return true;
+    case "US_CT":
+      return true;
+    case "US_DE":
+      return true;
+    case "US_HI":
+      return true;
+    case "US_RI":
+      return true;
+    case "US_VT":
+      return true;
+    default:
+      return false;
+  }
+};
+
+export default getIsUnified;


### PR DESCRIPTION
## Description of the change

This disables the jails tab for states which have unified systems. In the future we may break out pre-trial populations to the jails tab for these states, but it is a large change so for now we just disable it.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes #120 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
