### PR TITLE
Add percentage covered back into state wide confinement rate tooltip

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -236,7 +236,7 @@ const App = ({
     jailsMetricData,
     INCARCERATION_RATE_JAIL,
     ["Statewide", selectorCountyCode],
-    ["Statewide Confinement Rate (per 100k)", selectorCountyName]
+    ["Statewide Confinement Rate", selectorCountyName]
   );
 
   const incarcerationRateTopCountiesChartData = generateJailsChartData(

--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -168,7 +168,15 @@ const Chart = ({ title, hint, chartData, annual, countySelector }) => {
       callbacks: {
         title: (item) => `${months[item[0].xLabel.month]} ${item[0].xLabel.year}`,
         label: (tooltipItem, data) =>
-          `${data.datasets[tooltipItem.datasetIndex].label}: ${formatNumber(tooltipItem.value)}`,
+          `${
+            data.datasets[tooltipItem.datasetIndex].isStatewide
+              ? `${data.datasets[tooltipItem.datasetIndex].label} (${formatNumber(
+                  data.datasets[tooltipItem.datasetIndex].countyCoverageData[tooltipItem.index]
+                )}% counties represented)`
+              : data.datasets[tooltipItem.datasetIndex].label
+          }: ${formatNumber(tooltipItem.value)} ${
+            data.datasets.some((dataset) => dataset.county) ? "per 100k" : ""
+          }`,
       },
       backgroundColor: CONNECTING_LINE_COLOR,
       yPadding: 10,


### PR DESCRIPTION

## Description of the change

In #103 and #106, we had added the percentage of counties represented to the tooltip for the state-wide jail confinement rate. I think this must've been dropped when we merged the jails functionality back into `main`. This adds it back.

### Before

![Screen Shot 2021-07-30 at 1 39 42 PM](https://user-images.githubusercontent.com/3762913/127709361-c6bff909-5da7-46a7-b290-cf0838dacb97.png)

![Screen Shot 2021-07-30 at 1 39 52 PM](https://user-images.githubusercontent.com/3762913/127709332-1b7583d2-40a3-4fa9-8eb5-c6226872d654.png)

Corrections just to show it is unaffected

![Screen Shot 2021-07-30 at 1 38 45 PM](https://user-images.githubusercontent.com/3762913/127709378-8cea0073-df46-49a3-97dc-403ec359d53f.png)

### After

![Screen Shot 2021-07-30 at 1 38 22 PM](https://user-images.githubusercontent.com/3762913/127709443-cce3c67b-b63f-4022-9eab-5f2690b05b71.png)

![Screen Shot 2021-07-30 at 1 38 32 PM](https://user-images.githubusercontent.com/3762913/127709460-710b4afe-59ae-4bc1-882c-d9b16280aa41.png)

![Screen Shot 2021-07-30 at 1 38 45 PM](https://user-images.githubusercontent.com/3762913/127709471-e93e6718-c742-4239-9180-1b1076881cbc.png)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

refixes #99

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
