### PR TITLE
Adds note on when states abolished parole, if applicable.

### DIFF
--- a/src/utils/getAdditionalDescription.js
+++ b/src/utils/getAdditionalDescription.js
@@ -15,11 +15,26 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import getIsUnified from "./getIsUnified";
+import states from "../constants/states";
 
 // =============================================================================
+const whenStatesAbolishedParole = { US_DE: "1990", US_ME: "1976" };
+
 const getAdditionalDescription = (stateCode) => {
+  const descriptions = [];
   if (getIsUnified(stateCode)) {
-    return `This state operates a "unified corrections system," which combines the jail and prison systems. As such, some of the numbers below may include pretrial populations.`;
+    descriptions.push(
+      `This state operates a "unified corrections system," which combines the jail and prison systems. As such, some of the numbers below may include pretrial populations.`
+    );
+  }
+  if (stateCode in whenStatesAbolishedParole) {
+    descriptions.push(
+      `Note: ${states[stateCode]} abolished parole in ${whenStatesAbolishedParole[stateCode]}.`
+    );
+  }
+
+  if (descriptions.length) {
+    return descriptions.join(" ");
   }
   return null;
 };


### PR DESCRIPTION
## Description of the change

This adds notes to the top of the page identifying when a state abolished parole, if applicable. This plays nicely with the other optional text indicating whether a state is unified. Here are three screenshots showing, respectively, a state with no extra info, a state only with the parole info, and a state with both the parole and unification info.

<img width="968" alt="Screen Shot 2021-08-02 at 10 54 34 AM" src="https://user-images.githubusercontent.com/431895/127897639-0efe3497-be50-4a24-b706-5d7b8a626c2f.png">
<img width="977" alt="Screen Shot 2021-08-02 at 10 54 07 AM" src="https://user-images.githubusercontent.com/431895/127897646-f63f205e-7460-47b5-a67f-9a2a8f5de78c.png">
<img width="973" alt="Screen Shot 2021-08-02 at 10 53 44 AM" src="https://user-images.githubusercontent.com/431895/127897650-982b3e11-7153-499b-a0e7-f4dd212da2f6.png">


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #126 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
