### PR TITLE
Disable corrections tab if no data

### DIFF
--- a/src/components/MainPage/MainPage.js
+++ b/src/components/MainPage/MainPage.js
@@ -53,8 +53,18 @@ const MainPage = ({
 
   const [storedActiveTab, setActiveTab] = useState(localStorage.getItem(LS_TAB_KEY) || CORRECTIONS);
 
-  // Force the active tab to 'CORRECTIONS' in a unified state.
-  const activeTab = isUnified ? CORRECTIONS : storedActiveTab;
+  // Disable tabs based on data availability and if this is a unified state.
+  const availableTabs = [CORRECTIONS, JAILS].filter((value) => {
+    switch (value) {
+      case CORRECTIONS:
+        return hasMonthlyCorrectionsData || hasAnnualCorrectionsData;
+      case JAILS:
+        return hasJailsData && !isUnified;
+      default:
+        return true;
+    }
+  });
+  const activeTab = availableTabs.includes(storedActiveTab) ? storedActiveTab : availableTabs[0];
 
   const onActiveTabChange = (newTab) => {
     setActiveTab(newTab);
@@ -123,7 +133,12 @@ const MainPage = ({
       </header>
       {!hasNoData && (
         <>
-          <Tabs activeTab={activeTab} onTabChange={onActiveTabChange} isUnified={isUnified} />
+          <Tabs
+            activeTab={activeTab}
+            onTabChange={onActiveTabChange}
+            tabsWithData={availableTabs}
+            isUnified={isUnified}
+          />
           {activeTab === CORRECTIONS && (
             <div className="MainPage__range">
               <h3 className="MainPage__range-title">Data Aggregation Range</h3>

--- a/src/components/MainPage/Tabs.js
+++ b/src/components/MainPage/Tabs.js
@@ -20,29 +20,34 @@ import cn from "classnames";
 
 import { CORRECTIONS, JAILS } from "./constants";
 
-const Tabs = ({ activeTab, onTabChange, isUnified }) => {
+const Tabs = ({ activeTab, onTabChange, tabsWithData, isUnified }) => {
   const createOnTabChange = (tab) => () => {
     onTabChange(tab);
   };
+  const disableCorrections = !tabsWithData.includes(CORRECTIONS);
+  const disableJails = isUnified || !tabsWithData.includes(JAILS);
 
   return (
     <div className="MainPage__tabs">
       <button
         type="button"
-        className={cn("MainPage__tab", { MainPage__tab_active: activeTab === CORRECTIONS })}
-        onClick={createOnTabChange(CORRECTIONS)}
+        className={cn("MainPage__tab", {
+          MainPage__tab_active: activeTab === CORRECTIONS,
+          "MainPage__tab--disabled": disableCorrections,
+        })}
+        onClick={disableCorrections ? null : createOnTabChange(CORRECTIONS)}
       >
-        Corrections
+        Corrections{tabsWithData.includes(CORRECTIONS) || " (No Data)"}
       </button>
       <button
         type="button"
         className={cn("MainPage__tab", {
           MainPage__tab_active: activeTab === JAILS,
-          "MainPage__tab--disabled": isUnified,
+          "MainPage__tab--disabled": disableJails,
         })}
-        onClick={isUnified ? null : createOnTabChange(JAILS)}
+        onClick={disableJails ? null : createOnTabChange(JAILS)}
       >
-        Jails{isUnified && " (Not Applicable)"}
+        Jails{(isUnified && " (Not Applicable)") || (!tabsWithData.includes(JAILS) && " (No Data)")}
       </button>
     </div>
   );
@@ -51,6 +56,7 @@ const Tabs = ({ activeTab, onTabChange, isUnified }) => {
 Tabs.propTypes = {
   activeTab: PropTypes.oneOf([CORRECTIONS, JAILS]).isRequired,
   onTabChange: PropTypes.func.isRequired,
+  tabsWithData: PropTypes.arrayOf(PropTypes.string).isRequired,
   isUnified: PropTypes.bool.isRequired,
 };
 

--- a/src/components/MainPage/__tests__/Tabs.test.js
+++ b/src/components/MainPage/__tests__/Tabs.test.js
@@ -1,0 +1,97 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import React from "react";
+import { render } from "@testing-library/react";
+import Tabs from "../Tabs";
+import { CORRECTIONS, JAILS } from "../constants";
+
+describe("Tabs.js", () => {
+  const mockFn = jest.fn();
+
+  it("should render active button", () => {
+    const { queryAllByText } = render(
+      <Tabs
+        activeTab={CORRECTIONS}
+        onTabChange={mockFn}
+        tabsWithData={[CORRECTIONS, JAILS]}
+        isUnified={false}
+      />
+    );
+
+    expect(queryAllByText((_, element) => element.classList.contains("MainPage__tab_active")));
+  });
+
+  it("should not append suffix with data", () => {
+    const { container } = render(
+      <Tabs
+        activeTab={CORRECTIONS}
+        onTabChange={mockFn}
+        tabsWithData={[CORRECTIONS, JAILS]}
+        isUnified={false}
+      />
+    );
+
+    expect(container.querySelector("button:nth-child(1)").innerHTML).toBe("Corrections");
+    expect(container.querySelector("button:nth-child(2)").innerHTML).toBe("Jails");
+  });
+
+  it("should append suffix for corrections with no data", () => {
+    const { container } = render(
+      <Tabs activeTab={CORRECTIONS} onTabChange={mockFn} tabsWithData={[JAILS]} isUnified={false} />
+    );
+
+    expect(container.querySelector("button:nth-child(1)").innerHTML).toBe("Corrections (No Data)");
+    expect(container.querySelector("button:nth-child(2)").innerHTML).toBe("Jails");
+  });
+
+  it("should append suffix for jails with no data", () => {
+    const { container } = render(
+      <Tabs
+        activeTab={CORRECTIONS}
+        onTabChange={mockFn}
+        tabsWithData={[CORRECTIONS]}
+        isUnified={false}
+      />
+    );
+
+    expect(container.querySelector("button:nth-child(1)").innerHTML).toBe("Corrections");
+    expect(container.querySelector("button:nth-child(2)").innerHTML).toBe("Jails (No Data)");
+  });
+
+  it("should append suffix when unified", () => {
+    const { container } = render(
+      <Tabs
+        activeTab={CORRECTIONS}
+        onTabChange={mockFn}
+        tabsWithData={[CORRECTIONS, JAILS]}
+        isUnified
+      />
+    );
+
+    expect(container.querySelector("button:nth-child(1)").innerHTML).toBe("Corrections");
+    expect(container.querySelector("button:nth-child(2)").innerHTML).toBe("Jails (Not Applicable)");
+  });
+
+  it("should prefer unified suffix when also no data", () => {
+    const { container } = render(
+      <Tabs activeTab={CORRECTIONS} onTabChange={mockFn} tabsWithData={[CORRECTIONS]} isUnified />
+    );
+
+    expect(container.querySelector("button:nth-child(1)").innerHTML).toBe("Corrections");
+    expect(container.querySelector("button:nth-child(2)").innerHTML).toBe("Jails (Not Applicable)");
+  });
+});

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -50,7 +50,7 @@ const Switch = ({ activeTab, onTabChange, panesWithData }) => {
           "Switch__slide-right": activeTab === MONTHLY && isClicked,
         })}
         type="button"
-        onClick={createOnTabChange(MONTHLY)}
+        onClick={panesWithData.includes(MONTHLY) ? createOnTabChange(MONTHLY) : null}
       >
         Monthly{panesWithData.includes(MONTHLY) || " (No Data)"}
       </button>
@@ -60,7 +60,7 @@ const Switch = ({ activeTab, onTabChange, panesWithData }) => {
           "Switch__slide-left": activeTab === ANNUAL && isClicked,
         })}
         type="button"
-        onClick={createOnTabChange(ANNUAL)}
+        onClick={panesWithData.includes(ANNUAL) ? createOnTabChange(ANNUAL) : null}
       >
         Annual{panesWithData.includes(ANNUAL) || " (No Data)"}
       </button>


### PR DESCRIPTION
## Description of the change

Utah doesn't publish any corrections data. Before we had the Jails tab, we would present a special "No Data" treatment for the page and disable all components. Now that we have the Jails tab, and Utah has some jails data, we skip that treatment and still render both tabs. This updates that behavior to disable the corrections tab entirely if there is no corrections data (and same for Jails, but we currently have Jails data for all states that aren't unified, which is handled somewhat separately).

<img width="988" alt="Screen Shot 2021-08-06 at 4 02 49 PM" src="https://user-images.githubusercontent.com/3762913/128578810-dc747f09-708c-4cf6-a463-9115addd7c71.png">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

@hobuobi to add an issue if filed

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
