### PR TITLE
Fix bad percent change for NH

### DIFF
--- a/src/components/shared/Card/Card.js
+++ b/src/components/shared/Card/Card.js
@@ -208,7 +208,7 @@ const Card = ({
               )}
               <div className="Card__date-range">
                 {mostRecentDate}&nbsp;
-                {percentChange && <span>(compared to {comparedToDate})</span>}
+                {percentChange !== null && <span>(compared to {comparedToDate})</span>}
               </div>
             </div>
           </>

--- a/src/components/shared/Card/__tests__/Card.test.js
+++ b/src/components/shared/Card/__tests__/Card.test.js
@@ -65,6 +65,15 @@ describe("Card.js", () => {
     expect(screen.queryByText("(--%)")).toBeInTheDocument();
   });
 
+  it("should display comparisons if percent change is 0", () => {
+    render(
+      <Card title="Some title" number={15} percentChange={0} comparedToDate="November 2020" />
+    );
+
+    expect(screen.queryByText("(0%)")).toBeInTheDocument();
+    expect(screen.queryByText("(compared to November 2020)")).toBeInTheDocument();
+  });
+
   it("should render card date range section", () => {
     const { container } = render(
       <Card title="Some title" number={15} percentChange={-20} mostRecentDate="September 2020" />

--- a/src/utils/__tests__/generateFlowDiagramData.test.js
+++ b/src/utils/__tests__/generateFlowDiagramData.test.js
@@ -62,6 +62,26 @@ describe("generateFlowDiagramData.js", () => {
         comparedToMonth: 11,
       },
     ],
+    [ADMISSIONS_FROM_PAROLE]: [
+      {
+        value: 5,
+        valueChange: null,
+        percentChange: null,
+        year: 2019,
+        month: 11,
+      },
+    ],
+    [ADMISSIONS_FROM_PROBATION]: [
+      {
+        value: 5,
+        valueChange: 0,
+        percentChange: 0,
+        year: 2019,
+        month: 11,
+        comparedToYear: 2018,
+        comparedToMonth: 11,
+      },
+    ],
   };
   const mockHint = "some hint";
   const mockSourceText = "source text";
@@ -89,10 +109,8 @@ describe("generateFlowDiagramData.js", () => {
 
   it("should put isNotAvailable flag is no metric data provided", () => {
     expect(flowDiagramData.flowData[SUPERVISION_STARTS_PROBATION].isNotAvailable).toBe(true);
-    expect(flowDiagramData.flowData[ADMISSIONS_FROM_PROBATION].isNotAvailable).toBe(true);
     expect(flowDiagramData.flowData[POPULATION_PRISON].isNotAvailable).toBe(true);
     expect(flowDiagramData.flowData[POPULATION_PAROLE].isNotAvailable).toBe(true);
-    expect(flowDiagramData.flowData[ADMISSIONS_FROM_PAROLE].isNotAvailable).toBe(true);
   });
 
   it("should produce flow diagram card data", () => {
@@ -111,6 +129,24 @@ describe("generateFlowDiagramData.js", () => {
       number: 95,
       percentChange: 18,
       hint: mockHint,
+    });
+  });
+
+  it("should handle null comparison values", () => {
+    expect(flowDiagramData.flowData[ADMISSIONS_FROM_PAROLE]).toMatchObject({
+      number: 5,
+      numberChange: null,
+      percentChange: null,
+      comparedToDate: null,
+    });
+  });
+
+  it("should not null out zero changes", () => {
+    expect(flowDiagramData.flowData[ADMISSIONS_FROM_PROBATION]).toMatchObject({
+      number: 5,
+      numberChange: 0,
+      percentChange: 0,
+      comparedToDate: "December 2018",
     });
   });
 });

--- a/src/utils/generateFlowDiagramData.js
+++ b/src/utils/generateFlowDiagramData.js
@@ -96,7 +96,7 @@ const generateFlowDiagramData = (data, compareData, stateName, isAnnual) => {
           itemStateName: stateName,
           title: metricToCardName[metric],
           number: lastItem.value,
-          percentChange: lastItem.percentChange ? lastItem.percentChange * 100 : null,
+          percentChange: lastItem.percentChange !== null ? lastItem.percentChange * 100 : null,
           numberChange: lastItem.valueChange,
           sourceText: generateSourceText(
             lastItem.sourceName,
@@ -110,9 +110,10 @@ const generateFlowDiagramData = (data, compareData, stateName, isAnnual) => {
             ? `${months[datePublished.month]} ${datePublished.day}, ${datePublished.year}`
             : null,
           mostRecentDate: `${months[lastItem.month]} ${lastItem.year}`,
-          comparedToDate: lastItem.percentChange
-            ? `${months[lastItem.comparedToMonth]} ${lastItem.comparedToYear}`
-            : null,
+          comparedToDate:
+            lastItem.percentChange !== null
+              ? `${months[lastItem.comparedToMonth]} ${lastItem.comparedToYear}`
+              : null,
           item: lastItem,
           compareItem: compareLastItem,
         };


### PR DESCRIPTION
## Description of the change

We were doing some truthy/falsy comparisons when we needed to be explicitly checking against nulls so that we properly handle changes of 0.

See NH before:

![Screen Shot 2021-08-09 at 5 43 45 PM](https://user-images.githubusercontent.com/3762913/128791563-70235890-8280-4b5b-8da4-ee53e310d361.png)

after:

![Screen Shot 2021-08-09 at 5 28 14 PM](https://user-images.githubusercontent.com/3762913/128791532-4a3064e1-cd17-4e58-a006-fc56e16d58eb.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

@hobuobi to file issue if needed

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
