### PR TITLE
Handle edge cases in chart percentages

### DIFF
--- a/src/components/Chart/utils/__tests__/calcMetricPercentage.test.js
+++ b/src/components/Chart/utils/__tests__/calcMetricPercentage.test.js
@@ -33,4 +33,12 @@ describe("calcPercentage.js", () => {
   it("should work when array consists of the only data point", () => {
     expect(calcMetricPercentage([1])).toBe("0%");
   });
+
+  it("should handle decreases to zero", () => {
+    expect(calcMetricPercentage([1, 0])).toBe("-100%");
+  });
+
+  it("should handle increases from zero", () => {
+    expect(calcMetricPercentage([0, 1])).toBe("N/A");
+  });
 });

--- a/src/components/Chart/utils/calcMetricPercentage.js
+++ b/src/components/Chart/utils/calcMetricPercentage.js
@@ -34,10 +34,14 @@ function calcMetricPercentage(data) {
     return "0%";
   }
 
-  const filteredData = data.filter((item) => item);
+  const filteredData = data.filter((item) => item !== null);
 
   const ratio = filteredData[filteredData.length - 1] / filteredData[0];
   const diff = Math.round((ratio - 1) * 100);
+
+  if (!Number.isFinite(diff)) {
+    return "N/A";
+  }
 
   return `${diff > 0 ? "+" : ""}${diff}%`;
 }


### PR DESCRIPTION
## Description of the change

Some more null comparisons. This one was causing us to drop 0s from the line chart when calculating percentage differences. This fixes that, and also replaces "+Infinity%" and "-Infinity%" test with "N/A" instead.

Before:

![Screen Shot 2021-08-09 at 5 46 31 PM](https://user-images.githubusercontent.com/3762913/128792581-f6ffe24f-254f-4f1b-826e-d458f122ae66.png)

After:

![Screen Shot 2021-08-09 at 5 59 53 PM](https://user-images.githubusercontent.com/3762913/128792601-69edcd1e-2473-40d3-99f0-ae91bd87512a.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

@hobuobi to file an issue if necessary

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
